### PR TITLE
24722: Do not enroll users that purchase with a PO until the PO is processed

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/PostSubmitCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/PostSubmitCommand.cs
@@ -153,26 +153,13 @@ namespace Headstart.API.Commands
                         Activity = new List<ProcessResultAction>() { notifications }
                     });
 
-                } else if(!isCCPayment && includesCert)
+                } else if(!isCCPayment)
                 {
-                    //send template/data for PO + certs
+                    //send template/data for all POs
                     var notifications = await ProcessActivityCall(
                     ProcessType.Notification,
                     "Sending Order Submit Emails",
-                    _sendgridService.SendPurchaseOrderUpload(orderWorksheet, orderWorksheet.Order.xp?.POFileID, true));
-                    results.Add(new ProcessResult()
-                    {
-                        Type = ProcessType.Notification,
-                        Activity = new List<ProcessResultAction>() { notifications }
-                    });
-
-                } else if (!isCCPayment && !includesCert)
-                {
-                    // send data for PO only
-                    var notifications = await ProcessActivityCall(
-                    ProcessType.Notification,
-                    "Sending Order Submit Emails",
-                    _sendgridService.SendPurchaseOrderUpload(orderWorksheet, orderWorksheet.Order.xp?.POFileID, false));
+                    _sendgridService.SendPurchaseOrderUpload(orderWorksheet, orderWorksheet.Order.xp?.POFileID));
                     results.Add(new ProcessResult()
                     {
                         Type = ProcessType.Notification,

--- a/src/Middleware/src/Headstart.Common/AppSettings.cs
+++ b/src/Middleware/src/Headstart.Common/AppSettings.cs
@@ -100,6 +100,7 @@ namespace Headstart.Common
     {
         public string ApiKey { get; set; }
         public string FromEmail { get; set; }
+        public string ToLMSTeamEmail { get; set; }
         public string POUploadEmail { get; set; }
         public string CertOrderEmail { get; set; }
         public string CriticalSupportEmails { get; set; } // (Optional) Comma delimited list of emails that should be contacted when criticial failures occur that require manual intervention

--- a/src/Middleware/src/Headstart.Common/AppSettingsReadme.md
+++ b/src/Middleware/src/Headstart.Common/AppSettingsReadme.md
@@ -45,8 +45,9 @@
 |        SendgridSettings:CriticalSupportEmails         | (Optional) Comma delimited list of emails that should be contacted when criticial failures occur that require manual intervention                                                                                           |
 |           SendgridSettings:SupportCaseEmail           | (Optional) Email to send support cases to                                                                                                                                                                                   |
 |             SendgridSettings:BillingEmail             | (Optional) Email to send for payment, billing, or refund queries                                                                                                                                                            |
-			SendgridSettings:POUploadEmail					Email used to send LMS team PO pdfs that were uploaded by Users using PO as payment
-			SendgridSettings:CertOrderEmail					Email used to send LMS team notifiations when User places an order containing certification products
+			SendgridSettings:POUploadEmail					Email template used to send LMS team PO pdfs that were uploaded by Users using PO as payment
+			SendgridSettings:CertOrderEmail					Email template used to send LMS team notifiations when User places an order containing certification products
+			SendgridSettings:ToLMSTeamEmail				| The email of whom will recieve the notifications for certification and po emails 
 |        SendgridSettings:OrderSubmitTemplateID         | (Optional) (Optional but required to send OrderSubmit emails) ID for the template to be used for OrderSubmit emails                                                                                                         |
 |       SendgridSettings:OrderApprovalTemplateID        | (Optional but required to send OrderApproval emails) ID for template to be used for OrderApproval emails                                                                                                                    |
 |    SendgridSettings:LineItemStatusChangeTemplateID    | (Optional but required to send LineItemStatusChange emails) ID for template to be used for LineItemStatusChange emails                                                                                                      |

--- a/src/Middleware/src/Headstart.Common/Mappers/SendgridMappers.cs
+++ b/src/Middleware/src/Headstart.Common/Mappers/SendgridMappers.cs
@@ -2,6 +2,7 @@
 using Headstart.Models.Extended;
 using Headstart.Models.Headstart;
 using ordercloud.integrations.exchangerates;
+using OrderCloud.Catalyst;
 using OrderCloud.SDK;
 using System;
 using System.Collections.Generic;
@@ -63,10 +64,9 @@ namespace Headstart.Common.Mappers
             };
         }
 
-        public static PoOrderUploadTemplateData GetCertAndPoOrderData(HSOrder order, IList<HSLineItem> lineItems, bool includesCerts)
+        public static PoOrderUploadTemplateData GetPoOrderData(HSOrder order, IList<HSLineItem> lineItems)
         {
             var productsList = lineItems?
-                .Where(lineItem => lineItem?.xp?.IsCertification == true)
                 .Select(lineItem =>
                 {
                     return new LineItemProductData()
@@ -77,7 +77,8 @@ namespace Headstart.Common.Mappers
                         Quantity = lineItem?.Quantity,
                         LineTotal = lineItem?.LineTotal,
                         SpecCombo = GetSpecCombo(lineItem?.Specs),
-                        IsCertification = lineItem?.xp?.IsCertification
+                        IsCertification = lineItem?.xp?.IsCertification,
+                        IsSubOrBundle = (bool)(lineItem?.xp?.lms_SubscriptionUuid.IsNullOrEmpty())
                     };
                 });
             return new PoOrderUploadTemplateData()
@@ -85,8 +86,7 @@ namespace Headstart.Common.Mappers
                 FirstName = order?.FromUser?.FirstName,
                 LastName = order?.FromUser?.LastName,
                 OrderID = order?.ID,
-                Products = productsList,
-                IncludesCerts = includesCerts
+                Products = productsList
             };
         }
 

--- a/src/Middleware/src/Headstart.Common/Models/Headstart/HSLineItem.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Headstart/HSLineItem.cs
@@ -34,6 +34,7 @@ namespace Headstart.Models.Headstart
         public bool? CanValidateDocebo { get; set; }
         public int? QuantityAdded { get; set; }
         public bool? IsCertification { get; set; }
+        public string? lms_SubscriptionUuid { get; set; }
     }
 
     

--- a/src/Middleware/src/Headstart.Common/Models/SendGridModels.cs
+++ b/src/Middleware/src/Headstart.Common/Models/SendGridModels.cs
@@ -48,6 +48,7 @@ namespace Headstart.Common.Models
             public string SpecCombo { get; set; }
             public string MessageToBuyer { get; set; }
             public bool? IsCertification { get; set; }
+            public bool IsSubOrBundle { get; set; }
         }
 
         public class NewUserData

--- a/src/Middleware/src/Headstart.Common/Services/SendgridService.cs
+++ b/src/Middleware/src/Headstart.Common/Services/SendgridService.cs
@@ -37,7 +37,7 @@ namespace Headstart.Common.Services
 
         Task SendNewUserEmail(MessageNotification<PasswordResetEventBody> payload);
 
-        Task SendPurchaseOrderUpload(HSOrderWorksheet worksheet, string fileName, bool includesCerts);
+        Task SendPurchaseOrderUpload(HSOrderWorksheet worksheet, string fileName);
 
         Task SendCertOrderEmail(HSOrderWorksheet worksheet);
 
@@ -171,14 +171,14 @@ namespace Headstart.Common.Services
             }
         }
 
-        public async Task SendPurchaseOrderUpload(HSOrderWorksheet worksheet, string fileName, bool includesCerts)
+        public async Task SendPurchaseOrderUpload(HSOrderWorksheet worksheet, string fileName)
         {
             var fromEmail = new EmailAddress("no-reply@po-orders.com");
-            var toEmail = new EmailAddress("globaltraining@sitecore.com");
-            var certAndPoOrderData = SendgridMappers.GetCertAndPoOrderData(worksheet.Order, worksheet.LineItems, includesCerts);
+            var toEmail = new EmailAddress(_settings?.SendgridSettings?.ToLMSTeamEmail);
+            var PoOrderData = SendgridMappers.GetPoOrderData(worksheet.Order, worksheet.LineItems);
             var templateData = new EmailTemplate<PoOrderUploadTemplateData>()
             {
-                Data = certAndPoOrderData
+                Data = PoOrderData
             };
             var msg = MailHelper.CreateSingleTemplateEmail(fromEmail, toEmail, _settings?.SendgridSettings?.POUploadEmail, templateData);
             if (fileName != null)
@@ -197,7 +197,7 @@ namespace Headstart.Common.Services
         public async Task SendCertOrderEmail(HSOrderWorksheet worksheet)
         {
             var fromEmail = new EmailAddress("no-reply@certification-exam-orders.com");
-            var toEmail = new EmailAddress("globaltraining@sitecore.com");
+            var toEmail = new EmailAddress(_settings?.SendgridSettings?.ToLMSTeamEmail);
             var certOrderData = SendgridMappers.GetCertOrderTemplateData(worksheet.Order, worksheet.LineItems);
             var certTemplateData = new EmailTemplate<CertOrderTemplateData>()
             {

--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
@@ -98,12 +98,12 @@ export class OCMCheckoutPayment implements OnInit {
       this.disableCC = true
     }
     this.ListAddressesForBilling()
-    const lineItems = this.context.order.getLineItems()
-    lineItems.Items.forEach((line) => {
-      if (line?.Product?.xp?.lms_SubscriptionUuid && line.UnitPrice > 0) {
-        this.disablePO = true
-      }
-    })
+    //const lineItems = this.context.order.getLineItems()
+    // lineItems.Items.forEach((line) => {
+    //   if (line?.Product?.xp?.lms_SubscriptionUuid && line.UnitPrice > 0) {
+    //     this.disablePO = true
+    //   }
+    // })
     if (_order?.xp?.PONumber) {
       this.poNumber = _order.xp.PONumber
     }

--- a/src/UI/Buyer/src/app/components/orders/order-historical/order-historical.component.ts
+++ b/src/UI/Buyer/src/app/components/orders/order-historical/order-historical.component.ts
@@ -30,7 +30,7 @@ export class OCMOrderHistorical implements OnInit {
     this.supplierMail = "mailto:" + this.order.xp.QuoteSellerContactEmail
   }
   @Input() set uploadDocUrl(value: string) {
-    this.url = value.toString()
+    this.url = value?.toString()
   }
   order: HSOrder
   lineItems: HSLineItem[] = []


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description

For Reference: [Azure 24722](https://dev.azure.com/SCTechStack/ONETechBoard/_workitems/edit/24722) <!--  Ignore if PR from external developer -->

all products will now be available via PO. Subscription and bundle products will only subscribe a user if they are internal or paid via CC else it will shoot off email to LMS team for them to process PO & enroll Users manually once PO is processed on their end. Also moved the ToEmail address to appSettings to make it easier to update without code change moving forward & added a safe nav check