### PR TITLE
LMS 24722

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.docebo/OrderCloudIntegrationsDoceboService.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.docebo/OrderCloudIntegrationsDoceboService.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using ordercloud.integrations.docebo.Models;
 using ordercloud.integrations.docebo.Mappers;
 using OrderCloud.SDK;
+using static OrderCloud.SDK.WebhookPayloads;
 
 namespace ordercloud.integrations.docebo
 {
@@ -19,6 +20,7 @@ namespace ordercloud.integrations.docebo
         Task<DoceboSubscriptionResponse> SubscribeUsers(DoceboSubscriptionRequest request, string uuid);
         Task<DoceboUserSearchResponse> SearchUsers(string email);
         Task<DoceboEnrollmentResponse> UnEnrollUsers(List<DoceboItem> lineItems);
+        Task<DoceboEnrollmentResponse> UpdateUserEnrollment(List<DoceboItem> lineItems);
     }
 
     public class OrderCloudIntegrationsDoceboConfig
@@ -69,6 +71,13 @@ namespace ordercloud.integrations.docebo
         {
             DoceboToken token = await GetToken();
             return await this.Request($"manage/v1/user", token).SetQueryParam("search_text", email).GetJsonAsync<DoceboUserSearchResponse>();
+        }
+
+        public async Task<DoceboEnrollmentResponse> UpdateUserEnrollment(List<DoceboItem>  lineItems)
+        {
+            DoceboToken token = await GetToken();
+            DoceboEnrollmentRequest request = DoceboMapper.MapRequest(lineItems, true);
+            return await this.Request("learn/v1/enrollment/batch", token).SendJsonAsync(System.Net.Http.HttpMethod.Delete, request).ReceiveJson<DoceboEnrollmentResponse>();
         }
 
         public async Task<DoceboEnrollmentResponse> UnEnrollUsers(List<DoceboItem> lineItems  )

--- a/src/Middleware/integrations/ordercloud.integrations.docebo/OrderCloudIntegrationsDoceboService.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.docebo/OrderCloudIntegrationsDoceboService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -77,7 +77,7 @@ namespace ordercloud.integrations.docebo
         {
             DoceboToken token = await GetToken();
             DoceboEnrollmentRequest request = DoceboMapper.MapRequest(lineItems, true);
-            return await this.Request("learn/v1/enrollment/batch", token).SendJsonAsync(System.Net.Http.HttpMethod.Delete, request).ReceiveJson<DoceboEnrollmentResponse>();
+            return await this.Request("learn/v1/enrollment/batch", token).PostJsonAsync(request).ReceiveJson<DoceboEnrollmentResponse>();
         }
 
         public async Task<DoceboEnrollmentResponse> UnEnrollUsers(List<DoceboItem> lineItems  )

--- a/src/Middleware/src/Headstart.API/Controllers/OrderController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/OrderController.cs
@@ -50,6 +50,14 @@ namespace Headstart.Common.Controllers
         {
             return await _command.AcknowledgeQuoteOrder(orderID);
         }
+        /// <summary>
+        /// POST Process Purchase Order Line Items - i.e. subscribe or enroll user via Docebo API
+        /// </summary>
+        [HttpPost, Route("processpolineitems/{orderID}"), OrderCloudUserAuth(ApiRole.OrderAdmin)]
+        public async Task<Order> UpdatePOLineItems(string orderID)
+        {
+            return await _command.UpdatePurchaseOrder(orderID);
+        }
 
         /// <summary>
         /// LIST orders for a specific location as a buyer, ensures user has access to location orders

--- a/src/Middleware/src/Headstart.Common/Models/Headstart/HSOrder.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Headstart/HSOrder.cs
@@ -53,6 +53,7 @@ namespace Headstart.Models
         public bool? OrderOnBehalfOf { get; set; }
         public string POFileID { get; set; }
         public string Region { get; set; }
+        public bool? ProcessedPO { get; set; }
 
     }
 

--- a/src/UI/SDK/src/api/Orders.ts
+++ b/src/UI/SDK/src/api/Orders.ts
@@ -183,6 +183,16 @@ export default class Orders {
         return await httpClient.get(`/order/getquoteorder/${orderID}`, { params: {  accessToken, impersonating } });
       }
 
+      /**
+    * @param orderID ID of the order.
+    * @param accessToken Provide an alternative token to the one stored in the sdk instance (useful for impersonation).
+    */
+    public async ProcessPOLineItems(orderID: string, accessToken?: string ): Promise<RequiredDeep<HSOrder>> {
+        const impersonating = this.impersonating;
+        this.impersonating = false;
+        return await httpClient.post(`/order/processpolineitems/${orderID}`, {}, { params: {  accessToken, impersonating } });
+      }
+
    /**
     * @param locationID ID of the location.
     * @param options.search Word or phrase to search for.

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
@@ -23,43 +23,37 @@
       *ngIf="
         _order?.xp?.PaymentMethod === 'Purchase Order' && _order?.xp?.POFileID
       "
-      class="d-flex flex-column mb-3"
+      class="d-flex flex-column mt-4 mx-4"
     >
-      <div class="font-weight-bold">
-        PO Processed: <span *ngIf="!_order?.xp?.ProcessedPO">NO</span>
-        <span *ngIf="_order?.xp?.ProcessedPO">YES</span>
-      </div>
-      <br />
       <div class="form-group">
-        <label for="UpdateEnrollment"> Enrollments Updated</label>
-        <label class="d-block switch mb-0">
-          <input
-            class="form-check-input"
-            [attr.disabled]="_order?.xp?.ProcessedPO ? true : null"
-            type="checkbox"
-            [checked]="_order?.xp?.ProcessedPO"
-            (click)="handlePurchaseOrderLI(_order)"
-          /><span class="slider round"></span>
-        </label>
-        <!-- <label class="d-block switch mb-0">
-          <input
-            class="form-check-input"
-            [attr.disabled]="readonly ? true : null"
-            type="checkbox"
-            (click)="handleUpdateProduct($event, 'Product.Active')"
-            [checked]="_superHSProductEditable?.Product.Active"
-          />
-          <span class="slider round"></span>
-        </label> -->
+        <div class="font-weight-bolder text-muted text-uppercase">
+          PO Processed
+        </div>
+        <div class="form-group d-flex align-items-center">
+          <label
+            [ngClass]="{ invisible: _order?.xp?.ProcessedPO }"
+            for="NO"
+            class="font-weight-bold"
+            >No</label
+          >
+          <label class="d-block switch mx-1">
+            <input
+              class="form-check-input"
+              [attr.disabled]="_order?.xp?.ProcessedPO ? true : null"
+              type="checkbox"
+              [checked]="_order?.xp?.ProcessedPO"
+              (click)="handlePurchaseOrderLI(_order)"
+            />
+            <span class="slider round"></span>
+          </label>
+          <label
+            [ngClass]="{ invisible: !_order?.xp?.ProcessedPO }"
+            for="YES"
+            class="font-weight-bold"
+            >Yes</label
+          >
+        </div>
       </div>
-      <!-- <button
-        *ngIf="
-          _order?.xp?.PaymentMethod === 'Purchase Order' && _order?.xp?.POFileID
-        "
-        class="btn btn-outline-primary d-print-none"
-      >
-        Test
-      </button> -->
     </div>
     <div class="d-flex flex-column mb-3">
       <button

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
@@ -19,7 +19,49 @@
         >{{ _order?.xp?.OrderType }}</span
       >
     </h3>
-    <div class="d-flex flex-column">
+    <div
+      *ngIf="
+        _order?.xp?.PaymentMethod === 'Purchase Order' && _order?.xp?.POFileID
+      "
+      class="d-flex flex-column mb-3"
+    >
+      <div class="font-weight-bold">
+        PO Processed: <span *ngIf="!_order?.xp?.ProcessedPO">NO</span>
+        <span *ngIf="_order?.xp?.ProcessedPO">YES</span>
+      </div>
+      <br />
+      <div class="form-group">
+        <label for="UpdateEnrollment"> Enrollments Updated</label>
+        <label class="d-block switch mb-0">
+          <input
+            class="form-check-input"
+            [attr.disabled]="_order?.xp?.ProcessedPO ? true : null"
+            type="checkbox"
+            [checked]="_order?.xp?.ProcessedPO"
+            (click)="handlePurchaseOrderLI(_order)"
+          /><span class="slider round"></span>
+        </label>
+        <!-- <label class="d-block switch mb-0">
+          <input
+            class="form-check-input"
+            [attr.disabled]="readonly ? true : null"
+            type="checkbox"
+            (click)="handleUpdateProduct($event, 'Product.Active')"
+            [checked]="_superHSProductEditable?.Product.Active"
+          />
+          <span class="slider round"></span>
+        </label> -->
+      </div>
+      <!-- <button
+        *ngIf="
+          _order?.xp?.PaymentMethod === 'Purchase Order' && _order?.xp?.POFileID
+        "
+        class="btn btn-outline-primary d-print-none"
+      >
+        Test
+      </button> -->
+    </div>
+    <div class="d-flex flex-column mb-3">
       <button
         *ngIf="
           _order?.xp?.OrderType !== 'Quote' && orderDirection === 'Incoming'

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, Inject, OnInit } from '@angular/core'
+import {
+  Component,
+  Input,
+  Inject,
+  OnInit,
+  ChangeDetectorRef,
+} from '@angular/core'
 import { OrderService } from '@app-seller/orders/order.service'
 import {
   Address,
@@ -115,6 +121,7 @@ export class OrderDetailsComponent {
     private ocAddressService: OcAddressService,
     private rmaService: RMAService,
     private currentUserService: CurrentUserService,
+    private cdr: ChangeDetectorRef,
     @Inject(applicationConfiguration) private appConfig: AppConfig
   ) {
     this.isSellerUser = this.appAuthService.getOrdercloudUserType() === SELLER
@@ -181,9 +188,16 @@ export class OrderDetailsComponent {
   }
 
   async handlePurchaseOrderLI(order: HSOrder): Promise<void> {
-    console.log(order)
-    const results = await HeadStartSDK.Orders.ProcessPOLineItems(order.ID)
-    console.log(results)
+    try {
+      const results = await HeadStartSDK.Orders.ProcessPOLineItems(order.ID)
+      if (results) {
+        this._order.xp.ProcessedPO = true
+        this.cdr.detectChanges()
+      }
+    } catch (error) {
+      console.error('Error processing PO Line Items: ', error)
+      throw error
+    }
   }
 
   setCardType(payment): string {

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
@@ -180,6 +180,12 @@ export class OrderDetailsComponent {
     }
   }
 
+  async handlePurchaseOrderLI(order: HSOrder): Promise<void> {
+    console.log(order)
+    const results = await HeadStartSDK.Orders.ProcessPOLineItems(order.ID)
+    console.log(results)
+  }
+
   setCardType(payment): string {
     if (!payment.xp.cardType || payment.xp.cardType === null) {
       return 'Card'

--- a/src/UI/Seller/src/app/shared/services/configuration/table-display.ts
+++ b/src/UI/Seller/src/app/shared/services/configuration/table-display.ts
@@ -75,7 +75,7 @@ export const SUMMARY_RESOURCE_INFO_PATHS_DICTIONARY: SummaryResourceInfoPathsDic
     },
     orders: {
       toPrimaryHeader: 'ID',
-      toSecondaryHeader: 'xp.SubmittedOrderStatus',
+      toSecondaryHeader: 'xp.PaymentMethod',
       toImage: '',
       toExpandable: false,
     },


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
added UI & middleware changes that allow admin users to enroll Buyer Users into ILTs, bundles and subscriptions once LMS team processes their PO instead of them manually enrolling them via the docebo admin website. 
Also updated the Admin UI to display the PaymentMethod rather than Status. Status is not updated so all Orders currently show as "open" in the UI, with the update Orders with xp.PaymenMethod will display that data giving the Admin a better UX. 

For Reference: [Azure 24722](https://dev.azure.com/SCTechStack/ONETechBoard/_workitems/edit/24722) <!--  Ignore if PR from external developer -->

- [X] I have updated the acceptance criteria on the task so that it can be tested
