### PR TITLE
LMS 28962 bug fix

### DIFF
--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.ts
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.ts
@@ -202,7 +202,9 @@ export class PromotionEditComponent implements OnInit, OnChanges {
       .toPromise()
     this.suppliers.next(supplierResponse.Items)
     this.supplierMeta = supplierResponse.Meta
-    await this.selectSupplier(existingSupplierID || this.suppliers.value[0].ID)
+    await this.selectSupplier(
+      existingSupplierID || this.suppliers?.value[0]?.ID
+    )
   }
 
   async selectSupplier(supplierID: string): Promise<void> {

--- a/src/UI/Seller/src/app/promotions/promotion.service.ts
+++ b/src/UI/Seller/src/app/promotions/promotion.service.ts
@@ -82,19 +82,16 @@ export class PromotionService extends ResourceCrudService<Promotion> {
     selectedSupplier?: HSSupplier
   ): string {
     let eligibleExpression = ''
-    const skuArr = safeXp?.SKUs?.map((sku) => `item.ProductID = '${sku}'`)
+    const skuArr = safeXp?.SKUs?.map((sku) => `'${sku}'`)
     switch (safeXp?.AppliesTo) {
       case HSPromoEligibility.SpecificSupplier:
         eligibleExpression = `item.SupplierID = '${selectedSupplier?.ID}'`
         break
       case HSPromoEligibility.SpecificSKUs:
-        skuArr.forEach(
-          (exp, i) =>
-            (eligibleExpression =
-              i === 0
-                ? `${eligibleExpression} ${exp}`
-                : `${eligibleExpression} or ${exp}`)
-        )
+        eligibleExpression =
+          skuArr.length === 1
+            ? `item.ProductID = ${skuArr[0]}` // If only one SKU, use direct equality
+            : `item.ProductID.in(${skuArr.join(', ')})` // For multiple SKUs, use .in()
         break
       default:
         // NOTE: The default expression is "true", which will allow the promotion to be applied to any order


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Refactoring of method that builds eligible expression so that we no longer run into the 400 character limitation. Added safe nav to setUpSuppliers() to avoid error messages on the Admin when no value available. 

For Reference: [Azure 28962](https://dev.azure.com/SCTechStack/ONETechBoard/_workitems/edit/28962?src=WorkItemMention&src-action=artifact_link) <!--  Ignore if PR from external developer -->


