### PR TITLE
Lms 29835

### DIFF
--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.html
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.html
@@ -55,6 +55,16 @@
       for further assistance.</span
     >
   </div>
+  <div class="alert alert-warning" role="alert" *ngIf="containsSubscriptions">
+    <span
+      >Credit card purchase functionality for select products is unavailable. We
+      apologize for any inconvenience. Please submit a Purchase Order or contact
+      <a href="mailto:GlobalTraining@Sitecore.com" target="_blank"
+        >GlobalTraining@Sitecore.com</a
+      >
+      for further assistance.</span
+    >
+  </div>
   <ng-container
     *ngIf="
       orderSummaryMeta.LineItemCount &&
@@ -191,18 +201,43 @@
       *ngIf="
         orderSummaryMeta.LineItemCount &&
         selectedPaymentMethod === 'CreditCard' &&
-        order.Total > 0
+        order.Total > 0 &&
+        !disableCC
       "
       [billingAddressCountry]="stripeCountry"
     ></ocm-stripe-payment>
   </div>
+  <!-- add terms and conditions here -->
+  <div *ngIf="disableCC && containsSubscriptions" class="alert alert-info">
+    <p class="disclaimer-text">
+      By purchasing a Sitecore learning subscription, I acknowledge that I will
+      be charged a recurring fee every 12 months from the purchase date, unless
+      I cancel within 90 days of the renewal. To cancel, I must send a written
+      request to globaltraining@sitecore.com with my intent to cancel. In the
+      absence of a termination notice, the contract shall be renewed under the
+      same terms and conditions. I understand that by checking this box, I agree
+      to these terms.
+    </p>
+    <label>
+      <input type="checkbox" (change)="onTermsChecked($event)" />
+      I agree to the terms and conditions.
+    </label>
+  </div>
+
+  <!-- Add validation for the checkbox -->
+  <p *ngIf="!agreedToTerms" class="error-text">
+    You must agree to the terms and conditions before submitting your order.
+  </p>
+
   <button
     type="submit"
     (click)="onContinue()"
     *ngIf="selectedPaymentMethod === 'PurchaseOrder'"
     class="btn btn-primary btn-block-xs mt-4 mr-2"
     [disabled]="
-      !selectedBillingAddress || (poUploadSuccess === false && !isSitecorian)
+      !selectedBillingAddress ||
+      (poUploadSuccess === false && !isSitecorian) ||
+      !agreedToTerms
     "
   >
     Submit Order

--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
@@ -105,10 +105,9 @@ export class OCMCheckoutPayment implements OnInit {
       if (line?.Product?.xp?.lms_SubscriptionUuid && line.UnitPrice > 0) {
         this.disableCC = true
         this.containsSubscriptions = true
-        console.log('should set to true, value', this.disableCC)
       }
     })
-    console.log('this.disableCC', this.disableCC)
+
     if (_order?.xp?.PONumber) {
       this.poNumber = _order.xp.PONumber
     }
@@ -175,10 +174,6 @@ export class OCMCheckoutPayment implements OnInit {
     this.stripeCountry.emit(null)
     this.japanOrder = false
     this.poOnlyOrder = false
-    console.log(
-      'this.disableCC value in BillingAddress function',
-      this.disableCC
-    )
     this.showNewAddressForm = billingAddressID === this.NEW_ADDRESS_CODE
     this.selectedBillingAddress = this.existingBillingAddresses.Items.find(
       (address) => billingAddressID === address.ID

--- a/src/UI/Buyer/src/app/services/order/checkout.service.ts
+++ b/src/UI/Buyer/src/app/services/order/checkout.service.ts
@@ -131,6 +131,21 @@ export class CheckoutService {
     return await this.paymentHelper.ListPaymentsOnOrder(this.order.ID)
   }
 
+  //subscription acknowledgement
+  async subscriptionAcknowledgment(flag: boolean): Promise<void> {
+    const patch = { xp: { SubscriptionTermsAccepted: flag } }
+    try {
+      this.order = await this.patch(patch as HSOrder)
+    } catch (ex) {
+      if (ex.errors.Errors[0].ErrorCode === 'NotFound') {
+        if (ex?.errors?.Errors?.[0]?.Data.ObjectType === 'Order') {
+          throw Error('You no longer have access to this order')
+        }
+        throw Error(ex)
+      }
+    }
+  }
+
   // Integration Methods
   // order cloud sandbox service methods, to be replaced by updated sdk in the future
   async estimateShipping(): Promise<OrderWorksheet> {

--- a/src/UI/Buyer/src/app/services/order/order-state.service.ts
+++ b/src/UI/Buyer/src/app/services/order/order-state.service.ts
@@ -46,8 +46,9 @@ export class OrderStateService {
       },
       ClaimStatus: ClaimStatus.NoClaim,
       ShippingStatus: ShippingStatus.Processing,
-      Region: "N/A",
+      Region: 'N/A',
       OrderOnBehalfOf: false,
+      SubscriptionTermsAccepted: false,
     },
   }
   private orderSubject = new BehaviorSubject<HSOrder>(this.DefaultOrder)

--- a/src/UI/SDK/src/models/OrderXp.ts
+++ b/src/UI/SDK/src/models/OrderXp.ts
@@ -75,4 +75,5 @@ export interface OrderXp {
   POFileID?: string
   Region: string
   OrderOnBehalfOf: boolean
+  SubscriptionTermsAccepted: boolean
 }

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
@@ -344,6 +344,7 @@
     <div class="row">
       <div class="col-md-7">
         <!-- Placeholder to keep order summary in place -->
+        <p>{{ getSubscriptionAcknowledgment(_order) }}</p>
       </div>
       <div class="col-md-5">
         <!-- Order Summary (Totals, Tax, Discounts, Payments etc) -->

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
@@ -102,6 +102,7 @@ export class OrderDetailsComponent {
   orderAvatarInitials: string
   rmas: RMA[]
   url = null
+  subscriptionAcknowledgment: boolean
 
   @Input()
   set order(order: Order) {
@@ -388,6 +389,13 @@ export class OrderDetailsComponent {
         this._order.xp?.POFileID
       )
       return results
+    }
+    return null
+  }
+
+  getSubscriptionAcknowledgment(order: Order): string {
+    if (order?.xp?.SubscriptionTermsAccepted) {
+      return 'Subscription Terms and Conditions have been accepted'
     }
     return null
   }


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
subscription and bundle products will no longer be able to be purchased via credit card. when an order has a subscription or bundle as a line item they will need to agree to terms and conditions supplied by LMS Admin team in order for them to proceed to submitting PO. In seller/admin view Orders that have bundle or subscription product(s) & terms have been accepted at checkout then verbiage will display that confirms they have accepted. Orders prior to this enhancement will not have that value even if they include subscription/bundle products.

For Reference: [Azure 29835](https://dev.azure.com/SCTechStack/ONETechBoard/_workitems/edit/29835?src=WorkItemMention&src-action=artifact_link) <!--  Ignore if PR from external developer -->


