### PR TITLE
LMS 28935 - update logic to distinguish subscriptions vs bundles

### DIFF
--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
@@ -102,7 +102,7 @@ export class OCMCheckoutPayment implements OnInit {
     this.ListAddressesForBilling()
     const lineItems = this.context.order.getLineItems()
     lineItems.Items.forEach((line) => {
-      if (line?.Product?.xp?.lms_SubscriptionUuid && line.UnitPrice > 0) {
+      if (line?.Product?.xp?.isSubscription && line.UnitPrice > 0) {
         this.disableCC = true
         this.containsSubscriptions = true
       }

--- a/src/UI/SDK/src/models/ProductXp.ts
+++ b/src/UI/SDK/src/models/ProductXp.ts
@@ -60,4 +60,5 @@ export interface ProductXp {
   description?: string
   TaxCode?: string
   IsCertification?: boolean
+  isSubscription?: boolean
 }


### PR DESCRIPTION


<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
both product types have xp.lms_subscriptionUuid value even though bundles are one time products. Updated/Patched the active subscription products in Test to now include xp.isSubscription to distinguish them from bundles. Once approved by LMS team will need to patch Prod subscription products

For Reference: [Azure 28935](https://dev.azure.com/SCTechStack/ONETechBoard/_workitems/edit/29835?src=WorkItemMention&src-action=artifact_link) <!--  Ignore if PR from external developer -->


