### PR TITLE
LMS-config manager

### DIFF
--- a/src/Middleware/src/Headstart.Jobs/Headstart.Jobs.csproj
+++ b/src/Middleware/src/Headstart.Jobs/Headstart.Jobs.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Headstart.API\Headstart.API.csproj" />


### PR DESCRIPTION
## Description
In late september, the LMS-Jobs function app stopped sending lineItem order details to cosmos. Azure provided an error: Microsoft.Azure.Cosmos.Client: Could not load file or assembly 'System.Configuration.ConfigurationManager, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.

The package was listed at the transitive level, this PR specifically maps it into the LMS-Job function app.