### PR TITLE
LMS Secure-4295 fix

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.docebo/Models/DoceboToken.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.docebo/Models/DoceboToken.cs
@@ -10,7 +10,6 @@ namespace ordercloud.integrations.docebo.Models
         public int expires_in { get; set; }
         public string token_type { get; set; }
         public string scope { get; set; }
-        public string refresh_token { get; set; }
     }
 
 }

--- a/src/Middleware/src/Headstart.API/Controllers/DoceboController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/DoceboController.cs
@@ -24,20 +24,12 @@ namespace Headstart.API.Controllers
         /// <summary>
         /// POST PaymentIntentResponse
         /// </summary>
-        [HttpPost, Route("posttoken"), OrderCloudUserAuth(ApiRole.Shopper)]
-        public async Task<DoceboToken> Post([FromBody] DoceboToken request)
-        {
-            return await _docebo.GetToken();
-        }
+        //[HttpPost, Route("posttoken"), OrderCloudUserAuth(ApiRole.Shopper)]
+        //public async Task<DoceboToken> Post([FromBody] DoceboToken request)
+        //{
+        //    return await _docebo.GetToken();
+        //}
 
-        /// <summary>
-        /// GET Docebo Token For Local Testing Only
-        /// </summary>
-        [HttpGet, Route("gettoken")]
-        public async Task<DoceboToken> GetToken()
-        {
-            return await _docebo.GetToken();
-        }
 
         /// <summary>
         /// LIST users from Docebo


### PR DESCRIPTION
## Description
Addresses security issue found within the OC Middleware: Users had the ability to obtain Docebo LMS OAuth Tokens through a /gettokens exposed route. The following PR addresses several areas:
1. Removes the /docebo/gettoken route found within the DoceboController. Originally this was only intended for local testing but was exposed to production. Now users can only access the getToken method through other routes such enrollment or subscription calls. 
2. Removes the /docebo/posttoken route in the DoceboController. Similarly, this route was calling the getToken method (albeit with more roles required) but is seemingly not being used within the code and AppInsights indicates this route is not being used (0 calls in past 90 days). Currently commented out in the event testing indicates it needs to be added back in. 
3. Removes the RefreshToken within the DoceboToken model. 

For Reference: https://sitecore.atlassian.net/browse/SECURE-4295
