### PR TITLE
DoceboAuth Fixes

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.docebo/Models/DoceboUserSearchResponse.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.docebo/Models/DoceboUserSearchResponse.cs
@@ -28,52 +28,59 @@ namespace ordercloud.integrations.docebo.Models
     public class DoceboUserSearchItem
     {
         public string user_id { get; set; }
-        public string username { get; set; }
-        public string first_name { get; set; }
-        public string last_name { get; set; }
-        public string email { get; set; }
-        public string uuid { get; set; }
-        public bool is_manager { get; set; }
-        public string fullname { get; set; }
-        public string last_access_date { get; set; }
-        public string last_update { get; set; }
-        public string creation_date { get; set; }
-        public string status { get; set; }
-        public string avatar { get; set; }
-        public string language { get; set; }
-        public string lang_code { get; set; }
-        public object expiration_date { get; set; }
-        public string level { get; set; }
-        public string email_validation_status { get; set; }
-        public string send_notification { get; set; }
-        public string newsletter_optout { get; set; }
-        public object newsletter_optout_date { get; set; }
-        public string encoded_username { get; set; }
-        public string timezone { get; set; }
-        public object date_format { get; set; }
-        public string field_4 { get; set; }
-        public string field_5 { get; set; }
-        public string field_7 { get; set; }
-        public string field_9 { get; set; }
-        public string field_10 { get; set; }
-        public string field_11 { get; set; }
-        public string field_13 { get; set; }
-        public string field_15 { get; set; }
-        public string field_16 { get; set; }
-        public string field_17 { get; set; }
-        public string field_18 { get; set; }
-        public string field_19 { get; set; }
-        public object field_22 { get; set; }
-        public string field_23 { get; set; }
-        public string field_24 { get; set; }
-        public string field_28 { get; set; }
-        public string field_29 { get; set; }
-        public string[] multidomains { get; set; }
-        public Manager_Names manager_names { get; set; }
-        public object[] managers { get; set; }
-        public int active_subordinates_count { get; set; }
-        public string[] actions { get; set; }
-        public bool expired { get; set; }
+        //public string username { get; set; }
+        //public string first_name { get; set; }
+        //public string last_name { get; set; }
+        //public string email { get; set; }
+        //public string uuid { get; set; }
+        //public bool is_manager { get; set; }
+        //public string fullname { get; set; }
+        //public string last_access_date { get; set; }
+        //public string last_update { get; set; }
+        //public string creation_date { get; set; }
+        //public string status { get; set; }
+        //public string avatar { get; set; }
+        //public string language { get; set; }
+        //public string lang_code { get; set; }
+        //public object expiration_date { get; set; }
+        //public string level { get; set; }
+        //public string email_validation_status { get; set; }
+        //public string send_notification { get; set; }
+        //public string newsletter_optout { get; set; }
+        //public object newsletter_optout_date { get; set; }
+        //public string encoded_username { get; set; }
+        //public string timezone { get; set; }
+        //public object date_format { get; set; }
+        //public string field_4 { get; set; }
+        //public string field_5 { get; set; }
+        //public string field_7 { get; set; }
+        //public string field_9 { get; set; }
+        //public string field_10 { get; set; }
+        //public string field_11 { get; set; }
+        //public string field_13 { get; set; }
+        //public string field_15 { get; set; }
+        //public string field_16 { get; set; }
+        //public string field_17 { get; set; }
+        //public string field_18 { get; set; }
+        //public string field_19 { get; set; }
+        //public object field_22 { get; set; }
+        //public string field_23 { get; set; }
+        //public string field_24 { get; set; }
+        //public string field_28 { get; set; }
+        //public string field_29 { get; set; }
+        //public string[] multidomains { get; set; }
+        //public Manager_Names manager_names { get; set; }
+        //public object[] managers { get; set; }
+        //public int active_subordinates_count { get; set; }
+        //public string[] actions { get; set; }
+        //public bool expired { get; set; }
+    }
+
+    // Returned to Shopper-role callers via the public controller route.
+    // Contains no PII — only indicates whether a matching Docebo account exists.
+    public class DoceboUserExistsResponse
+    {
+        public bool exists { get; set; }
     }
 
     public class Manager_Names

--- a/src/Middleware/src/Headstart.API/Controllers/DoceboController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/DoceboController.cs
@@ -1,11 +1,13 @@
-﻿using System.Threading.Tasks;
-using Headstart.Models.Attributes;
+﻿using Headstart.Models.Attributes;
 using Microsoft.AspNetCore.Mvc;
 using ordercloud.integrations.docebo;
+using ordercloud.integrations.docebo.Models;
 using ordercloud.integrations.library;
 using OrderCloud.Catalyst;
 using OrderCloud.SDK;
-using ordercloud.integrations.docebo.Models;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace Headstart.API.Controllers
 {
@@ -16,9 +18,11 @@ namespace Headstart.API.Controllers
     public class DoceboController : CatalystController
     {
         private readonly IOrderCloudIntegrationsDoceboService _docebo;
-        public DoceboController(IOrderCloudIntegrationsDoceboService docebo)
+        private readonly IOrderCloudClient _oc;
+        public DoceboController(IOrderCloudIntegrationsDoceboService docebo, IOrderCloudClient oc)
         {
             _docebo = docebo;
+            _oc = oc;
         }
 
         /// <summary>
@@ -30,14 +34,27 @@ namespace Headstart.API.Controllers
         //    return await _docebo.GetToken();
         //}
 
-
         /// <summary>
-        /// LIST users from Docebo
+        /// Returns whether a Docebo account exists for the given email.
+        /// No PII is included in the response.
         /// </summary>
         [HttpGet, Route("{email}"), OrderCloudUserAuth(ApiRole.Shopper)]
-        public async Task<DoceboUserSearchResponse> ListDoceboUsers(string email)
+        public async Task<DoceboUserExistsResponse> ListDoceboUsers(string email)
         {
-            return await _docebo.SearchUsers(email);
+            var currentUser = await _oc.Me.GetAsync(accessToken: UserContext.AccessToken);
+            var callerDomain = currentUser.Email.Split('@').Last();
+            var requestedDomain = email.Split('@').Last();
+
+            Require.That(
+                callerDomain.Equals(requestedDomain, System.StringComparison.OrdinalIgnoreCase),
+                new ErrorCode("Insufficient Access", "You may only search for users within your own email domain.", HttpStatusCode.Forbidden)
+            );
+
+            var result = await _docebo.SearchUsers(email);
+            return new DoceboUserExistsResponse
+            {
+                exists = result?.data?.items?.Any() ?? false
+            };
         }
     }
 }

--- a/src/UI/Buyer/src/app/components/cart/cart/cart.component.ts
+++ b/src/UI/Buyer/src/app/components/cart/cart/cart.component.ts
@@ -114,7 +114,7 @@ export class OCMCart implements OnInit, OnDestroy {
         const searchResult = await this.context.order.searchDoceboUsers(email)
         const result = {
           learner: email,
-          found: searchResult.data.count > 0 ? true : false,
+          found: searchResult,
         }
         return result
       })

--- a/src/UI/Buyer/src/app/services/order/order.service.ts
+++ b/src/UI/Buyer/src/app/services/order/order.service.ts
@@ -16,7 +16,6 @@ import {
   HSLineItem,
   QuoteOrderInfo,
   HeadStartSDK,
-  DoceboUserSearchResponse,
 } from '@ordercloud/headstart-sdk'
 import { PromoService } from './promo.service'
 import { AppConfig } from 'src/app/models/environment.types'
@@ -64,11 +63,9 @@ export class CurrentOrderService {
     await HeadStartSDK.Orders.SendQuoteRequestToSupplier(orderID, lineItemID)
   }
 
-  public async searchDoceboUsers(
-    email: string
-  ): Promise<DoceboUserSearchResponse> {
-    const userResponse = await HeadStartSDK.DoceboUsers.SearchUsers(email)
-    return userResponse
+  public async searchDoceboUsers(email: string): Promise<boolean> {
+    const response = await HeadStartSDK.DoceboUsers.SearchUsers(email)
+    return response.exists ?? false
   }
 
   get cart(): CartService {

--- a/src/UI/SDK/src/api/DoceboUsers.ts
+++ b/src/UI/SDK/src/api/DoceboUsers.ts
@@ -1,4 +1,4 @@
-import { DoceboUserSearchResponse } from '../models/DoceboUserSearchResponse';
+import { DoceboUserExistsResponse, DoceboUserSearchResponse } from '../models/DoceboUserSearchResponse';
 import { RequiredDeep } from '../models/RequiredDeep';
 import httpClient from '../utils/HttpClient';
 
@@ -17,7 +17,7 @@ export default class DoceboUsers {
     * @param email Email of the learner
     * @param accessToken Provide an alternative token to the one stored in the sdk instance (useful for impersonation).
     */
-    public async SearchUsers(email: string,  accessToken?: string ): Promise<RequiredDeep<DoceboUserSearchResponse>> {
+    public async SearchUsers(email: string,  accessToken?: string ): Promise<RequiredDeep<DoceboUserExistsResponse>> {
         const impersonating = this.impersonating;
         this.impersonating = false;
         return await httpClient.get(`/docebo/${email}`, { params: {  accessToken, impersonating } } );

--- a/src/UI/SDK/src/models/DoceboUserSearchResponse.ts
+++ b/src/UI/SDK/src/models/DoceboUserSearchResponse.ts
@@ -4,6 +4,10 @@ export interface DoceboUserSearchResponse {
     _links: any[];
 }
 
+export interface DoceboUserExistsResponse {
+    exists: boolean;
+}
+
 export interface DoceboUserSearchData {
     items: DoceboUserSearchItem[];
     count: number;
@@ -18,62 +22,6 @@ export interface DoceboUserSearchData {
 
 export interface DoceboUserSearchItem {
     user_id: string;
-    username: string;
-    first_name: string;
-    last_name: string;
-    email: string;
-    uuid: string;
-    is_manager: boolean;
-    fullname: string;
-    last_access_date: string;
-    last_update: string;
-    creation_date: string;
-    status: string;
-    avatar: string;
-    language: string;
-    lang_code: string;
-    expiration_date: any;
-    level: string;
-    email_validation_status: string;
-    send_notification: string;
-    newsletter_optout: string;
-    newsletter_optout_date: any;
-    encoded_username: string;
-    timezone: string;
-    date_format: any;
-    field_4: string;
-    field_5: string;
-    field_7: string;
-    field_9: string;
-    field_10: string;
-    field_11: string;
-    field_13: string;
-    field_15: string;
-    field_16: string;
-    field_17: string;
-    field_18: string;
-    field_19: string;
-    field_22: any;
-    field_23: string;
-    field_24: string;
-    field_28: string;
-    field_29: string;
-    multidomains: string[];
-    manager_names: Manager_Names;
-    managers: any[];
-    active_subordinates_count: number;
-    actions: string[];
-    expired: boolean;
-}
-
-export interface Manager_Names {
-    _1: _1;
-}
-
-export interface _1 {
-    manager_title: string;
-    manager_name: any;
-    manager_username: any;
 }
 
 export interface DoceboUserSearchSort {


### PR DESCRIPTION
## Description
Hotfix for exposed public Docebo route, additional work will need to be planned out. The issue and fix is as follows: 

The /docebo/{email} route is required to be public in order for users to purchase products on behalf of others within their organization as we need to validate if they user they intend to purchase for have accounts. On the front-end there is a check that prevents-users from making the call to /docebo/{email} if the email of the onBehalfUser does not match the domain of the user purchasing. 

1. Middleware logic to restrict users to searching within their own domain
This logic has been added into the middleware as well, meaning an additional check happens if any user attempted to use their email they are limited to their own company. (i.e. if my user purchasing has an email of @sitecore.com then I can only purchase/call this route for other users with @sitecore.com emails).

2. removal of PII data
The DoceboUserSearchResponse object was returning PII data that was not needed. Everything except the user_id has been removed from the object as that is the only value used internally during the orderSubmit process. Additionally, before returning a value on the public route, rather than return the user_id itself, we now are checking if it exists and assigning that value to a boolean: Exists.

So, if a user makes out a call to /docebo/{email} the only response they will get will be: {"exists":true/false}. 

Testing:
The sandboxdocebo clientID is not valid so testing was not able to be completed in that environment. Instead, I hooked up both the middleware and local buyer app to the production OC instance, I went through the Order on behalf flow up to the checkout page and confirmed I was able to receive the expected {"exists":true} for a known user. Similarly, I am returned the proper messaging for users not found and users not recognized.

